### PR TITLE
Add recommendations results UI: shared list, cards, and detail naviga…

### DIFF
--- a/NextFlix/app/src/main/AndroidManifest.xml
+++ b/NextFlix/app/src/main/AndroidManifest.xml
@@ -2,6 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-permission android:name="android.permission.INTERNET" />
+
     <application
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"

--- a/NextFlix/app/src/main/java/com/example/nextflix/MainActivity.kt
+++ b/NextFlix/app/src/main/java/com/example/nextflix/MainActivity.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.unit.sp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.nextflix.navigation.OnboardingNavHost
+import com.example.nextflix.navigation.ResultsNavHost
 import com.example.nextflix.ui.screens.MoviePreferenceQuizScreen
 import com.example.nextflix.ui.theme.NextFlixTheme
 import com.example.nextflix.ui.screens.BookPreferenceQuizScreen
@@ -131,7 +132,7 @@ fun NextFlixApp(
                     onNavigateBack = { selectedTab = AppTab.HOME }
                 )
                 AppTab.BOOK_QUIZ -> BookPreferenceQuizScreen()
-                AppTab.RESULTS -> PlaceholderScreen("Results", "Coming soon!")
+                AppTab.RESULTS -> ResultsNavHost()
                 AppTab.FAVORITES -> PlaceholderScreen("Favorites", "Coming soon!")
             }
         }

--- a/NextFlix/app/src/main/java/com/example/nextflix/data/recommendation/RecommendationModels.kt
+++ b/NextFlix/app/src/main/java/com/example/nextflix/data/recommendation/RecommendationModels.kt
@@ -1,0 +1,75 @@
+package com.example.nextflix.data.recommendation
+
+enum class RecommendationContentType {
+    MOVIE,
+    BOOK
+}
+
+/**
+ * Unified model for a recommended movie or book shown in lists and detail.
+ */
+data class RecommendationItem(
+    val id: String,
+    val contentType: RecommendationContentType,
+    val title: String,
+    val imageUrl: String?,
+    val summary: String,
+    /** Display string e.g. "8.4/10" or "4.5★"; null if unknown */
+    val rating: String?
+)
+
+object SampleRecommendations {
+    val movies: List<RecommendationItem> = listOf(
+        RecommendationItem(
+            id = "m1",
+            contentType = RecommendationContentType.MOVIE,
+            title = "The Grand Horizon",
+            imageUrl = "https://picsum.photos/seed/movie1/400/600",
+            summary = "An explorer returns home to mend old ties while chasing one last adventure across coastal towns.",
+            rating = "8.4/10"
+        ),
+        RecommendationItem(
+            id = "m2",
+            contentType = RecommendationContentType.MOVIE,
+            title = "Midnight in Arcadia",
+            imageUrl = "https://picsum.photos/seed/movie2/400/600",
+            summary = "A composer hears music no one else can, leading her through a city that shifts after dark.",
+            rating = null
+        ),
+        RecommendationItem(
+            id = "m3",
+            contentType = RecommendationContentType.MOVIE,
+            title = "Paper Planes & Thunder",
+            imageUrl = "https://picsum.photos/seed/movie3/400/600",
+            summary = "Childhood friends reunite to finish a film they abandoned a decade ago.",
+            rating = "7.9/10"
+        )
+    )
+
+    val books: List<RecommendationItem> = listOf(
+        RecommendationItem(
+            id = "b1",
+            contentType = RecommendationContentType.BOOK,
+            title = "The Salt Orchard",
+            imageUrl = "https://picsum.photos/seed/book1/400/600",
+            summary = "A botanist inherits a failing orchard and uncovers letters that rewrite her family story.",
+            rating = "4.5★"
+        ),
+        RecommendationItem(
+            id = "b2",
+            contentType = RecommendationContentType.BOOK,
+            title = "Letters Never Sent",
+            imageUrl = "https://picsum.photos/seed/book2/400/600",
+            summary = "Epistolary novel about two archivists falling in love one redacted line at a time.",
+            rating = null
+        ),
+        RecommendationItem(
+            id = "b3",
+            contentType = RecommendationContentType.BOOK,
+            title = "Orbit of Quiet Things",
+            imageUrl = "https://picsum.photos/seed/book3/400/600",
+            summary = "Quiet science fiction about a station where sound was outlawed—and the librarian who remembers songs.",
+            rating = "4.2★"
+        )
+    )
+}

--- a/NextFlix/app/src/main/java/com/example/nextflix/navigation/ResultsNavHost.kt
+++ b/NextFlix/app/src/main/java/com/example/nextflix/navigation/ResultsNavHost.kt
@@ -1,0 +1,61 @@
+package com.example.nextflix.navigation
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
+import com.example.nextflix.ui.screens.RecommendationDetailScreen
+import com.example.nextflix.ui.screens.RecommendationResultsScreen
+import com.example.nextflix.ui.viewmodel.RecommendationViewModel
+
+private object ResultsRoutes {
+    const val List = "recommendation_list"
+    const val Detail = "recommendation_detail"
+}
+
+@Composable
+fun ResultsNavHost(
+    viewModel: RecommendationViewModel = viewModel()
+) {
+    val navController = rememberNavController()
+
+    NavHost(
+        navController = navController,
+        startDestination = ResultsRoutes.List
+    ) {
+        composable(ResultsRoutes.List) {
+            val items by viewModel.visibleItems.collectAsStateWithLifecycle()
+            val contentFilter by viewModel.contentFilter.collectAsStateWithLifecycle()
+            RecommendationResultsScreen(
+                items = items,
+                contentFilter = contentFilter,
+                onContentFilterChange = { viewModel.setContentFilter(it) },
+                onItemClick = { item ->
+                    viewModel.openDetail(item)
+                    navController.navigate(ResultsRoutes.Detail)
+                }
+            )
+        }
+        composable(ResultsRoutes.Detail) {
+            val selectedDetail by viewModel.selectedDetail.collectAsStateWithLifecycle()
+            val item = selectedDetail
+            if (item == null) {
+                LaunchedEffect(Unit) {
+                    navController.popBackStack(ResultsRoutes.List, inclusive = false)
+                }
+            } else {
+                RecommendationDetailScreen(
+                    item = item,
+                    onBack = {
+                        viewModel.clearDetail()
+                        navController.popBackStack()
+                    }
+                )
+            }
+        }
+    }
+}

--- a/NextFlix/app/src/main/java/com/example/nextflix/ui/components/RecommendationResultCard.kt
+++ b/NextFlix/app/src/main/java/com/example/nextflix/ui/components/RecommendationResultCard.kt
@@ -1,0 +1,170 @@
+package com.example.nextflix.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.MenuBook
+import androidx.compose.material.icons.filled.Movie
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.painter.ColorPainter
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import com.example.nextflix.data.recommendation.RecommendationContentType
+import com.example.nextflix.data.recommendation.RecommendationItem
+
+@Composable
+fun RecommendationResultCard(
+    item: RecommendationItem,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Card(
+        modifier = modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick),
+        shape = RoundedCornerShape(16.dp),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant),
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(12.dp),
+            verticalAlignment = Alignment.Top
+        ) {
+            PosterOrPlaceholder(item = item, modifier = Modifier.width(96.dp))
+            Spacer(modifier = Modifier.width(12.dp))
+            Column(modifier = Modifier.weight(1f)) {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(6.dp)
+                ) {
+                    Icon(
+                        imageVector = when (item.contentType) {
+                            RecommendationContentType.MOVIE -> Icons.Default.Movie
+                            RecommendationContentType.BOOK -> Icons.AutoMirrored.Filled.MenuBook
+                        },
+                        contentDescription = null,
+                        modifier = Modifier.size(18.dp),
+                        tint = MaterialTheme.colorScheme.primary
+                    )
+                    Text(
+                        text = item.title,
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.SemiBold,
+                        maxLines = 2,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                }
+                Spacer(modifier = Modifier.height(6.dp))
+                Text(
+                    text = item.summary,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 3,
+                    overflow = TextOverflow.Ellipsis
+                )
+                if (item.rating != null) {
+                    Spacer(modifier = Modifier.height(8.dp))
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Icon(
+                            imageVector = Icons.Default.Star,
+                            contentDescription = null,
+                            modifier = Modifier.size(16.dp),
+                            tint = MaterialTheme.colorScheme.tertiary
+                        )
+                        Spacer(modifier = Modifier.width(4.dp))
+                        Text(
+                            text = item.rating,
+                            style = MaterialTheme.typography.labelLarge,
+                            color = MaterialTheme.colorScheme.onSurface
+                        )
+                    }
+                } else {
+                    Spacer(modifier = Modifier.height(4.dp))
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun MovieResultCard(
+    item: RecommendationItem,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    RecommendationResultCard(item = item, onClick = onClick, modifier = modifier)
+}
+
+@Composable
+fun BookResultCard(
+    item: RecommendationItem,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    RecommendationResultCard(item = item, onClick = onClick, modifier = modifier)
+}
+
+@Composable
+private fun PosterOrPlaceholder(
+    item: RecommendationItem,
+    modifier: Modifier = Modifier
+) {
+    val shape = RoundedCornerShape(12.dp)
+    if (item.imageUrl.isNullOrBlank()) {
+        Box(
+            modifier = modifier
+                .aspectRatio(2f / 3f)
+                .clip(shape)
+                .background(MaterialTheme.colorScheme.surfaceContainerHighest),
+            contentAlignment = Alignment.Center
+        ) {
+            Icon(
+                imageVector = when (item.contentType) {
+                    RecommendationContentType.MOVIE -> Icons.Default.Movie
+                    RecommendationContentType.BOOK -> Icons.AutoMirrored.Filled.MenuBook
+                },
+                contentDescription = null,
+                modifier = Modifier.size(40.dp),
+                tint = MaterialTheme.colorScheme.outline
+            )
+        }
+    } else {
+        val placeholder = ColorPainter(MaterialTheme.colorScheme.surfaceContainerHighest)
+        AsyncImage(
+            model = item.imageUrl,
+            contentDescription = item.title,
+            modifier = modifier
+                .aspectRatio(2f / 3f)
+                .clip(shape),
+            contentScale = ContentScale.Crop,
+            placeholder = placeholder,
+            error = placeholder
+        )
+    }
+}

--- a/NextFlix/app/src/main/java/com/example/nextflix/ui/screens/RecommendationDetailScreen.kt
+++ b/NextFlix/app/src/main/java/com/example/nextflix/ui/screens/RecommendationDetailScreen.kt
@@ -1,0 +1,171 @@
+package com.example.nextflix.ui.screens
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Surface
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.MenuBook
+import androidx.compose.material.icons.filled.Movie
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.painter.ColorPainter
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import com.example.nextflix.data.recommendation.RecommendationContentType
+import com.example.nextflix.data.recommendation.RecommendationItem
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun RecommendationDetailScreen(
+    item: RecommendationItem,
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Scaffold(
+        modifier = modifier,
+        topBar = {
+            CenterAlignedTopAppBar(
+                title = {
+                    Text(
+                        text = item.title,
+                        maxLines = 1,
+                        style = MaterialTheme.typography.titleMedium
+                    )
+                },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "Back"
+                        )
+                    }
+                },
+                colors = TopAppBarDefaults.centerAlignedTopAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.surface
+                )
+            )
+        }
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = 16.dp, vertical = 8.dp)
+        ) {
+            val shape = RoundedCornerShape(16.dp)
+            if (item.imageUrl.isNullOrBlank()) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth(0.55f)
+                        .aspectRatio(2f / 3f)
+                        .clip(shape)
+                        .background(MaterialTheme.colorScheme.surfaceContainerHighest)
+                        .align(Alignment.CenterHorizontally),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Icon(
+                        imageVector = when (item.contentType) {
+                            RecommendationContentType.MOVIE -> Icons.Default.Movie
+                            RecommendationContentType.BOOK -> Icons.AutoMirrored.Filled.MenuBook
+                        },
+                        contentDescription = null,
+                        modifier = Modifier.size(64.dp),
+                        tint = MaterialTheme.colorScheme.outline
+                    )
+                }
+            } else {
+                val ph = ColorPainter(MaterialTheme.colorScheme.surfaceContainerHighest)
+                AsyncImage(
+                    model = item.imageUrl,
+                    contentDescription = item.title,
+                    modifier = Modifier
+                        .fillMaxWidth(0.55f)
+                        .aspectRatio(2f / 3f)
+                        .clip(shape)
+                        .align(Alignment.CenterHorizontally),
+                    contentScale = ContentScale.Crop,
+                    placeholder = ph,
+                    error = ph
+                )
+            }
+            Spacer(modifier = Modifier.height(16.dp))
+            Surface(
+                shape = RoundedCornerShape(8.dp),
+                color = MaterialTheme.colorScheme.primaryContainer
+            ) {
+                Text(
+                    text = when (item.contentType) {
+                        RecommendationContentType.MOVIE -> "Movie"
+                        RecommendationContentType.BOOK -> "Book"
+                    },
+                    modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp),
+                    style = MaterialTheme.typography.labelLarge,
+                    color = MaterialTheme.colorScheme.onPrimaryContainer
+                )
+            }
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = item.title,
+                style = MaterialTheme.typography.headlineSmall,
+                fontWeight = FontWeight.Bold
+            )
+            if (item.rating != null) {
+                Spacer(modifier = Modifier.height(8.dp))
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Icon(
+                        imageVector = Icons.Default.Star,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.tertiary,
+                        modifier = Modifier.size(22.dp)
+                    )
+                    Spacer(modifier = Modifier.width(6.dp))
+                    Text(
+                        text = item.rating,
+                        style = MaterialTheme.typography.titleMedium
+                    )
+                }
+            }
+            Spacer(modifier = Modifier.height(16.dp))
+            Text(
+                text = "About",
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.SemiBold
+            )
+            Spacer(modifier = Modifier.height(6.dp))
+            Text(
+                text = item.summary,
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            Spacer(modifier = Modifier.height(24.dp))
+        }
+    }
+}

--- a/NextFlix/app/src/main/java/com/example/nextflix/ui/screens/RecommendationResultsScreen.kt
+++ b/NextFlix/app/src/main/java/com/example/nextflix/ui/screens/RecommendationResultsScreen.kt
@@ -1,0 +1,84 @@
+package com.example.nextflix.ui.screens
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.example.nextflix.data.recommendation.RecommendationContentType
+import com.example.nextflix.data.recommendation.RecommendationItem
+import com.example.nextflix.ui.components.BookResultCard
+import com.example.nextflix.ui.components.MovieResultCard
+
+@Composable
+fun RecommendationResultsScreen(
+    items: List<RecommendationItem>,
+    contentFilter: RecommendationContentType,
+    onContentFilterChange: (RecommendationContentType) -> Unit,
+    onItemClick: (RecommendationItem) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Column(modifier = modifier.fillMaxSize()) {
+        Text(
+            text = "Recommendations",
+            style = MaterialTheme.typography.headlineSmall,
+            fontWeight = FontWeight.Bold,
+            modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
+        )
+        Text(
+            text = "Browse picks tailored to your taste. Switch between movies and books.",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp)
+        )
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 8.dp),
+            horizontalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            FilterChip(
+                selected = contentFilter == RecommendationContentType.MOVIE,
+                onClick = { onContentFilterChange(RecommendationContentType.MOVIE) },
+                label = { Text("Movies") }
+            )
+            FilterChip(
+                selected = contentFilter == RecommendationContentType.BOOK,
+                onClick = { onContentFilterChange(RecommendationContentType.BOOK) },
+                label = { Text("Books") }
+            )
+        }
+        LazyColumn(
+            modifier = Modifier.fillMaxSize(),
+            contentPadding = PaddingValues(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            items(items, key = { it.id }) { item ->
+                when (item.contentType) {
+                    RecommendationContentType.MOVIE -> MovieResultCard(
+                        item = item,
+                        onClick = { onItemClick(item) }
+                    )
+                    RecommendationContentType.BOOK -> BookResultCard(
+                        item = item,
+                        onClick = { onItemClick(item) }
+                    )
+                }
+            }
+            item { Spacer(modifier = Modifier.height(8.dp)) }
+        }
+    }
+}

--- a/NextFlix/app/src/main/java/com/example/nextflix/ui/viewmodel/RecommendationViewModel.kt
+++ b/NextFlix/app/src/main/java/com/example/nextflix/ui/viewmodel/RecommendationViewModel.kt
@@ -1,0 +1,47 @@
+package com.example.nextflix.ui.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.nextflix.data.recommendation.RecommendationContentType
+import com.example.nextflix.data.recommendation.RecommendationItem
+import com.example.nextflix.data.recommendation.SampleRecommendations
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
+
+class RecommendationViewModel : ViewModel() {
+
+    private val _contentFilter = MutableStateFlow(RecommendationContentType.MOVIE)
+    val contentFilter: StateFlow<RecommendationContentType> = _contentFilter
+
+    val visibleItems: StateFlow<List<RecommendationItem>> = _contentFilter
+        .map { filter ->
+            when (filter) {
+                RecommendationContentType.MOVIE -> SampleRecommendations.movies
+                RecommendationContentType.BOOK -> SampleRecommendations.books
+            }
+        }
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5_000),
+            initialValue = SampleRecommendations.movies
+        )
+
+    private val _selectedDetail = MutableStateFlow<RecommendationItem?>(null)
+    val selectedDetail: StateFlow<RecommendationItem?> = _selectedDetail
+
+    fun setContentFilter(type: RecommendationContentType) {
+        _contentFilter.value = type
+    }
+
+    fun openDetail(item: RecommendationItem) {
+        _selectedDetail.value = item
+    }
+
+    fun clearDetail() {
+        _selectedDetail.update { null }
+    }
+}


### PR DESCRIPTION
Issues Covered

- Issue 17: Build shared Recommendation Results screen
- Issue 18: Build reusable movie and book result cards
- Issue 19: Add navigation from results to detail screen

Summary of Changes

- Added shared recommendation results screen for books and movies
- Added reusable result cards for both content types
- Supported scrolling through multiple results
- Kept results layout reusable and visually consistent
- Added tap navigation from result cards to detail screen
- Passed correct selected result data to the detail screen
- Handled missing images and ratings without breaking the UI

